### PR TITLE
Add unit tests for GET endpoints

### DIFF
--- a/PlantsApi.Tests/PlantsApi.Tests.csproj
+++ b/PlantsApi.Tests/PlantsApi.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PlantsApi\PlantsApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PlantsApi.Tests/PlantsControllerTests.cs
+++ b/PlantsApi.Tests/PlantsControllerTests.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Mvc;
+using PlantsApi.Controllers;
+using PlantsApi.Models;
+using FluentAssertions;
+
+namespace PlantsApi.Tests;
+
+public class PlantsControllerTests
+{
+    private readonly PlantsController _controller;
+
+    public PlantsControllerTests()
+    {
+        _controller = new PlantsController();
+    }
+
+    [Fact]
+    public void GetAllPlants_ReturnsOkResult_WithListOfPlants()
+    {
+        // Act
+        var result = _controller.GetAllPlants();
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var okResult = result.Result as OkObjectResult;
+        okResult?.Value.Should().BeAssignableTo<IEnumerable<Plant>>();
+        
+        var plants = okResult?.Value as IEnumerable<Plant>;
+        plants.Should().NotBeNull();
+        plants.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void GetPlantById_WithValidId_ReturnsOkResult_WithPlant()
+    {
+        // Arrange
+        int validId = 1;
+
+        // Act
+        var result = _controller.GetPlantById(validId);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var okResult = result.Result as OkObjectResult;
+        okResult?.Value.Should().BeOfType<Plant>();
+        
+        var plant = okResult?.Value as Plant;
+        plant.Should().NotBeNull();
+        plant?.Id.Should().Be(validId);
+        plant?.Name.Should().Be("Monstera");
+    }
+
+    [Fact]
+    public void GetPlantById_WithInvalidId_ReturnsNotFoundResult()
+    {
+        // Arrange
+        int invalidId = 999;
+
+        // Act
+        var result = _controller.GetPlantById(invalidId);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+        var notFoundResult = result.Result as NotFoundObjectResult;
+        notFoundResult.Should().NotBeNull();
+    }
+
+    [Theory]
+    [InlineData(1, "Monstera")]
+    [InlineData(2, "Snake Plant")]
+    [InlineData(3, "Pothos")]
+    public void GetPlantById_ReturnsCorrectPlant_ForEachId(int id, string expectedName)
+    {
+        // Act
+        var result = _controller.GetPlantById(id);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var okResult = result.Result as OkObjectResult;
+        var plant = okResult?.Value as Plant;
+        
+        plant.Should().NotBeNull();
+        plant?.Name.Should().Be(expectedName);
+    }
+}


### PR DESCRIPTION
- Created xUnit test project (PlantsApi.Tests)
- Added reference to main project
- Installed FluentAssertions for readable assertions
- Added 6 unit tests:
  - GetAllPlants returns OK with 3 plants
  - GetPlantById with valid ID returns OK with plant
  - GetPlantById with invalid ID returns NotFound
  - Theory test for all 3 plant IDs
- Updated CI pipeline to run tests
- All tests passing locally and in CI

Closes #7